### PR TITLE
Changes to Get-CSGroupInfo

### DIFF
--- a/host-group/Get-CsGroupInfo.psm1
+++ b/host-group/Get-CsGroupInfo.psm1
@@ -42,18 +42,12 @@ function Get-CsGroupInfo {
                 accept         = 'application/json'
                 'content-type' = 'application/json'
             }
+            Uri    = '/devices/combined/host-groups/v1?limit=' + [string] $Limit + '&offset=' + [string] $Offset
         }
-        switch ($PSBoundParameters.Keys) {
+        Switch ($PSBoundParameters.Keys) {
+            'Filter' { $Param.Uri += '&filter=' + $Filter }
             'Id' { $Param['Uri'] = '/devices/entities/host-groups/v1?ids=' + ($Id -join '&ids=') }
             'Verbose' { $Param['Verbose'] = $true }
-            default { 
-                $Param['Uri'] = '/devices/combined/host-groups/v1?limit=' + [string] $Limit +
-                '&offset=' + [string] $Offset
-
-                if ($Filter) {
-                    $Param.Uri += '&filter=' + $Filter
-                }
-            }
         }
         Invoke-FalconAPI @Param
     }

--- a/host-group/Get-CsGroupInfo.psm1
+++ b/host-group/Get-CsGroupInfo.psm1
@@ -1,5 +1,5 @@
 function Get-CsGroupInfo {
-<#
+    <#
     .SYNOPSIS
         Search for info about Host Groups
 
@@ -15,27 +15,31 @@ function Get-CsGroupInfo {
     .PARAMETER OFFSET
         The offset to start retrieving records from [Default: 0] (when IDs are not provided)
 #>
-    [CmdletBinding()]
+    [CmdLetBinding(DefaultParameterSetName = 'Default')]
     [OutputType([psobject])]
     param(
+        [Parameter(ParameterSetName = 'Id')]
         [array]
         $Id,
 
+        [Parameter(ParameterSetName = 'noId')]
         [string]
         $Filter,
 
-        [ValidateRange(2,500)]
+        [Parameter(ParameterSetName = 'noId')]
+        [ValidateRange(2, 500)]
         [int]
         $Limit = 500,
 
+        [Parameter(ParameterSetName = 'noId')]
         [int]
         $Offset = 0
     )
-    process{
+    process {
         $Param = @{
             Method = 'get'
             Header = @{
-                accept = 'application/json'
+                accept         = 'application/json'
                 'content-type' = 'application/json'
             }
         }


### PR DESCRIPTION
As using parameter 'Id' excludes the usage of 'Filter', 'Limit' and 'Offset' I have set these as separate ParameterSets to ensure they are only able to be used in that manner.

Running Get-CSGroupInfo with no parameters fails, as `default` on `Switch ($PSBoundParameters.Keys)` will never be executed (and therefore no Uri is set).

To fix that I moved the Uri var to the initial block (it will get overwritten if Id is specified), and added Filter to the switch logic.