### PR TITLE
Change variable used to detect pwsh version for compatability

### DIFF
--- a/oauth2/Get-CsToken.psm1
+++ b/oauth2/Get-CsToken.psm1
@@ -83,7 +83,7 @@ function Get-CsToken {
             Body = 'client_id=' + [string] $Falcon.id + '&client_secret='
         }
         # Add secret to token request
-        if ($Host.Version.Major -gt 5) {
+        if ($PSVersionTable.PSVersion.Major -gt 5) {
             $Param.Body += ($Falcon.secret | ConvertFrom-SecureString -AsPlainText)
         } else {
             $Param.Body += ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto(

--- a/tools/Invoke-CsAPI.psm1
+++ b/tools/Invoke-CsAPI.psm1
@@ -80,7 +80,7 @@ function Invoke-CsAPI {
             $Param['ProxyUseDefaultCredentials'] = $true
         }
         # Add UseBasicParsing for older PowerShell versions
-        if ($Host.Version.Major -lt 6) {
+        if ($PSVersionTable.PSVersion.Major -lt 6) {
             $Param['UseBasicParsing'] = $true
         }
         # Remove progress bar to speed up file downloads (Invoke-WebRequest bug)


### PR DESCRIPTION
Fixes #16 

Tested in Powershell 5.1 and 7.0