### PR TITLE
Fix min pwsh ver for AsPlainText on SecureString

### DIFF
--- a/oauth2/Get-CsToken.psm1
+++ b/oauth2/Get-CsToken.psm1
@@ -83,7 +83,7 @@ function Get-CsToken {
             Body = 'client_id=' + [string] $Falcon.id + '&client_secret='
         }
         # Add secret to token request
-        if ($PSVersionTable.PSVersion.Major -gt 5) {
+        if ($PSVersionTable.PSVersion.Major -gt 6) {
             $Param.Body += ($Falcon.secret | ConvertFrom-SecureString -AsPlainText)
         } else {
             $Param.Body += ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto(


### PR DESCRIPTION
Associated fix for #16 
(fixes #16)

Pwsh v6 does not support `asplaintext` on `ConvertFrom-SecureString` .. only pwsh7+