### PR TITLE
Remove lower casing of filter strings per #19

### DIFF
--- a/firewall-policies/Get-CsFirewallPolicyId.psm1
+++ b/firewall-policies/Get-CsFirewallPolicyId.psm1
@@ -41,7 +41,7 @@ function Get-CsFirewallPolicyId {
             }
         }
         switch ($PSBoundParameters.Keys) {
-            'Filter' { $Param.Uri += '&filter=' + $Filter.ToLower() }
+            'Filter' { $Param.Uri += '&filter=' + $Filter }
             'Verbose' { $Param['Verbose'] = $true }
             'Debug' { $Param['Debug'] = $true }
         }

--- a/firewall-policies/Get-CsFirewallPolicyInfo.psm1
+++ b/firewall-policies/Get-CsFirewallPolicyInfo.psm1
@@ -52,7 +52,7 @@ function Get-CsFirewallPolicyInfo {
             }
         }
         switch ($PSBoundParameters.Keys) {
-            'Filter' { $Param.Uri += '&filter=' + $Filter.ToLower() }
+            'Filter' { $Param.Uri += '&filter=' + $Filter }
             'Id' { $Param.Uri = '/policy/entities/firewall/v1?ids=' }
             'Verbose' { $Param['Verbose'] = $true }
             'Debug' { $Param['Debug'] = $true }

--- a/host-group/Get-CsGroupId.psm1
+++ b/host-group/Get-CsGroupId.psm1
@@ -41,7 +41,7 @@ function Get-CsGroupId {
             }
         }
         switch ($PSBoundParameters.Keys) {
-            'Filter' { $Param.Uri += '&filter=' + $Filter.ToLower() }
+            'Filter' { $Param.Uri += '&filter=' + $Filter }
             'Verbose' { $Param['Verbose'] = $true }
             'Debug' { $Param['Debug'] = $true }
         }

--- a/host-group/Get-CsGroupInfo.psm1
+++ b/host-group/Get-CsGroupInfo.psm1
@@ -52,7 +52,7 @@ function Get-CsGroupInfo {
             }
         }
         switch ($PSBoundParameters.Keys) {
-            'Filter' { $Param.Uri += '&filter=' + $Filter.ToLower() }
+            'Filter' { $Param.Uri += '&filter=' + $Filter }
             'Id' { $Param.Uri = '/devices/entities/host-groups/v1?ids=' }
             'Verbose' { $Param['Verbose'] = $true }
             'Debug' { $Param['Debug'] = $true }

--- a/hosts/Get-CsHostId.psm1
+++ b/hosts/Get-CsHostId.psm1
@@ -48,7 +48,7 @@ function Get-CsHostId {
         }
         switch ($PSBoundParameters.Keys) {
             'Hidden' { $Param.Uri = '/devices/queries/devices-hidden/v1?limit=' + [string] $Limit }
-            'Filter' { $Param.Uri += '&filter=' + $Filter.ToLower() }
+            'Filter' { $Param.Uri += '&filter=' + $Filter }
             'Offset' { $Param.Uri += '&offset=' + $Offset }
             'Debug' { $Param['Debug'] = $true }
             'Verbose' { $Param['Verbose'] = $true }


### PR DESCRIPTION
See #19 for details - This removes all cases where a filter string is lower cased, given that filters are case sensitive, and this may break them.

Feel free to close this out, but it solved the issue for me.

A few alternative approaches:

* ToLower by default, but offer a switch param to not mess with Filter
* Don't ToLower by default, but offer a switch parameter to do so

IMHO it makes the most sense not to break casing sent by the user, but this is my first day working with CrowdStrike, so mayyyy be missing the context around this!