### PR TITLE
Add Queue Offline option to Start-RTRBatch

### DIFF
--- a/real-time-response/Start-RtrBatch.psm1
+++ b/real-time-response/Start-RtrBatch.psm1
@@ -13,6 +13,10 @@ function Start-RtrBatch {
 
     .PARAMETER TIMEOUT
         Time to wait for the command request to complete, in seconds [default: 30]
+        
+    .PARAMETER QUEUEOFFLINE
+        Optional switch to queue the RTR command for offline hosts
+        
 #>
     [CmdletBinding()]
     [OutputType([psobject])]
@@ -28,6 +32,10 @@ function Start-RtrBatch {
         [ValidateRange(30,600)]
         [int]
         $Timeout = 30
+        
+        [switch]
+        $QueueOffline
+        
     )
     process{
         $Param = @{
@@ -43,6 +51,7 @@ function Start-RtrBatch {
         }
         switch ($PSBoundParameters.Keys) {
             'Existing' { $Param.Body['existing_batch_id'] = $Existing }
+            'QueueOffline' { $Param.Body['queue_offline'] = $true }
             'Verbose' { $Param['Verbose'] = $true }
             'Debug' { $Param['Debug'] = $true }
         }


### PR DESCRIPTION
https://assets.falcon.crowdstrike.com/support/api/swagger.html#/real-time-response/BatchInitSessions

The example value for `/real-time-response/combined/batch-init-session/v1` seems to include an `queue_offline` option that will show up in the results when you run a command, but it doesn't look implemented in here yet.